### PR TITLE
fix: スクロールしているコンテンツがoverlayをはみ出して見えるので修正

### DIFF
--- a/hosting/src/components/common/Sidebar.module.css
+++ b/hosting/src/components/common/Sidebar.module.css
@@ -1,7 +1,10 @@
 .overlay {
   position: fixed;
-  inset: 0;
+  top: 0;
+  left: 0;
   z-index: 10;
+  width: 100%;
+  height: 100dvh;
   background-color: rgb(0 0 0 / 30%);
 }
 
@@ -12,7 +15,7 @@
   z-index: 20;
   display: none;
   width: var(--sidebar-width);
-  height: 100%;
+  height: 100dvh;
   padding: 1rem;
   overflow-y: auto;
   background-color: var(--color-bg);

--- a/hosting/src/components/common/Sidebar.tsx
+++ b/hosting/src/components/common/Sidebar.tsx
@@ -15,9 +15,16 @@ interface SidebarProps {
 
 export const Sidebar = ({ open, onClose }: SidebarProps) => {
   useEffect(() => {
-    document.body.classList.toggle('menu-open', open)
+    if (!open) return
+
+    const scrollY = window.scrollY
+    document.body.style.top = `-${scrollY}px`
+    document.body.classList.add('menu-open')
+
     return () => {
       document.body.classList.remove('menu-open')
+      document.body.style.top = ''
+      window.scrollTo(0, scrollY)
     }
   }, [open])
 

--- a/hosting/src/styles/base.css
+++ b/hosting/src/styles/base.css
@@ -4,6 +4,8 @@ body {
 }
 
 body.menu-open {
+  position: fixed;
+  width: 100%;
   overflow: hidden;
 }
 


### PR DESCRIPTION
## Issues

https://github.com/marucc/frontend-engineer-codecheck/issues/2#issuecomment-4018012540

## なに

- オーバーレイを開く時にスクロール位置を計算してbody位置調整
