### PR TITLE
fix: xAxis,yAxisのtitle位置が重なったり切れていたので修正

### DIFF
--- a/hosting/src/components/chart/Chart.tsx
+++ b/hosting/src/components/chart/Chart.tsx
@@ -47,7 +47,10 @@ export const Chart = () => {
     () => ({
       chart: { margin: [35, 30, 45, 70] },
       title: { text: undefined },
-      xAxis: { title: { text: '年', align: 'high', x: 20, y: -20 }, type: 'linear' },
+      xAxis: {
+        title: { text: '年', align: 'high', x: 20, y: -20 },
+        type: 'linear',
+      },
       yAxis: {
         title: {
           text: '人口数',


### PR DESCRIPTION
## Issues

https://github.com/marucc/frontend-engineer-codecheck/issues/24#issuecomment-4020328778

## なに

- xAxis,yAxisのtitle位置調整
