### PR TITLE
fix: チェックボックス表示、グラフ線の凡例はラベル右に表示

### DIFF
--- a/hosting/src/components/controls/PrefectureSelector.module.css
+++ b/hosting/src/components/controls/PrefectureSelector.module.css
@@ -36,18 +36,6 @@
   color: #dc2626;
 }
 
-.srOnly {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  white-space: nowrap;
-  border: 0;
-  clip-path: inset(50%);
-}
-
 .label {
   display: flex;
   gap: 0.25rem;
@@ -58,14 +46,56 @@
   transition: color 0.15s;
 }
 
-.label:hover {
-  color: var(--color-text);
+.checkbox {
+  position: relative;
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  width: 1rem;
+  height: 1rem;
+  overflow: visible;
+  appearance: none;
+  cursor: pointer;
+  background-color: transparent;
+  border: 1.5px solid var(--color-border);
+  border-radius: 3px;
+  transition:
+    background-color 0.15s,
+    border-color 0.15s;
 }
 
-.label:has(:focus-visible) {
-  outline: 2px solid #3b82f6;
+.checkbox:checked {
+  border-color: var(--color-border);
+}
+
+.checkbox::after {
+  position: absolute;
+  width: 8px;
+  height: 14px;
+  content: '';
+  border-right: 2.5px solid var(--color-text-muted);
+  border-bottom: 2.5px solid var(--color-text-muted);
+  opacity: 0;
+  transform: rotate(45deg) translate(-1px, -3.5px);
+  transition: opacity 0.1s;
+}
+
+.checkbox:checked::after {
+  opacity: 1;
+}
+
+.checkbox:focus-visible {
+  outline: 2px solid var(--color-text-muted);
   outline-offset: 2px;
-  border-radius: 2px;
+}
+
+.checkbox:hover:not(:checked) {
+  border-color: #9ca3af;
+}
+
+.label:hover {
+  color: var(--color-text);
 }
 
 .label.selected {

--- a/hosting/src/components/controls/PrefectureSelector.tsx
+++ b/hosting/src/components/controls/PrefectureSelector.tsx
@@ -51,26 +51,26 @@ export const PrefectureSelector = () => {
               >
                 <input
                   type="checkbox"
-                  className={styles.srOnly}
+                  className={styles.checkbox}
                   name="prefecture"
                   checked={selectedCodes.has(pref.prefCode)}
                   onChange={(e) =>
                     handleChange(pref.prefCode, pref.prefName, e.target.checked)
                   }
                 />
-                <span
-                  className={styles.legendIcon}
-                  style={{ color: style?.color ?? '#ccc' }}
-                >
-                  <span className={styles.legendLine} />
-                  {style && (
+                {pref.prefName}
+                {style && (
+                  <span
+                    className={styles.legendIcon}
+                    style={{ color: style.color }}
+                  >
+                    <span className={styles.legendLine} />
                     <span
                       className={styles.marker}
                       data-symbol={style.symbol}
                     />
-                  )}
-                </span>
-                {pref.prefName}
+                  </span>
+                )}
               </label>
             )
           })}


### PR DESCRIPTION
## Issues

https://github.com/marucc/frontend-engineer-codecheck/issues/33

## なに

- チェックボックス表示、グラフ線の凡例はラベル右に表示
