### PR TITLE
fix: 都道府県チェック時の排他制御とローディング追加

### DIFF
--- a/hosting/src/components/chart/Chart.test.tsx
+++ b/hosting/src/components/chart/Chart.test.tsx
@@ -27,6 +27,9 @@ describe('Chart', () => {
     vi.mocked(usePopulationContext).mockReturnValue({
       populations: [],
       populationType: '総人口',
+      selectedCodes: new Set<number>(),
+      loadingCodes: new Set<number>(),
+      error: null,
       addPrefecture: vi.fn(),
       removePrefecture: vi.fn(),
     })
@@ -54,6 +57,9 @@ describe('Chart', () => {
         },
       ],
       populationType: '総人口',
+      selectedCodes: new Set<number>(),
+      loadingCodes: new Set<number>(),
+      error: null,
       addPrefecture: vi.fn(),
       removePrefecture: vi.fn(),
     })

--- a/hosting/src/components/controls/PrefectureSelector.module.css
+++ b/hosting/src/components/controls/PrefectureSelector.module.css
@@ -103,6 +103,23 @@
   color: var(--color-text);
 }
 
+.spinner {
+  display: inline-block;
+  flex-shrink: 0;
+  width: 0.75rem;
+  height: 0.75rem;
+  border: 2px solid var(--color-border);
+  border-top-color: var(--color-text-muted);
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .legendIcon {
   position: relative;
   display: inline-flex;

--- a/hosting/src/components/controls/PrefectureSelector.test.tsx
+++ b/hosting/src/components/controls/PrefectureSelector.test.tsx
@@ -5,6 +5,7 @@ import { PrefectureSelector } from './PrefectureSelector'
 
 const mockAddPrefecture = vi.fn()
 const mockRemovePrefecture = vi.fn()
+let mockSelectedCodes = new Set<number>()
 
 vi.mock('../../hooks/usePrefectures', () => ({
   usePrefectures: vi.fn(),
@@ -13,6 +14,11 @@ vi.mock('../../hooks/usePrefectures', () => ({
 vi.mock('../../hooks/usePopulationContext', () => ({
   usePopulationContext: () => ({
     populations: [],
+    get selectedCodes() {
+      return mockSelectedCodes
+    },
+    loadingCodes: new Set<number>(),
+    error: null,
     addPrefecture: mockAddPrefecture,
     removePrefecture: mockRemovePrefecture,
   }),
@@ -27,6 +33,7 @@ const mockPrefectures = [
 describe('PrefectureSelector', () => {
   afterEach(() => {
     vi.clearAllMocks()
+    mockSelectedCodes = new Set()
   })
 
   it('全都道府県がチェックボックスとして表示される', () => {
@@ -55,6 +62,8 @@ describe('PrefectureSelector', () => {
   })
 
   it('チェック済みを外すと removePrefecture が呼ばれる', () => {
+    mockSelectedCodes = new Set([13])
+
     vi.mocked(usePrefectures).mockReturnValue({
       prefectures: mockPrefectures,
       loading: false,
@@ -62,7 +71,6 @@ describe('PrefectureSelector', () => {
     })
 
     render(<PrefectureSelector />)
-    fireEvent.click(screen.getByLabelText('東京都'))
     fireEvent.click(screen.getByLabelText('東京都'))
     expect(mockRemovePrefecture).toHaveBeenCalledWith(13)
   })

--- a/hosting/src/components/controls/PrefectureSelector.tsx
+++ b/hosting/src/components/controls/PrefectureSelector.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useMemo } from 'react'
 
 import { usePopulationContext } from '../../hooks/usePopulationContext'
 import { usePrefectures } from '../../hooks/usePrefectures'
@@ -6,10 +6,15 @@ import { getSeriesStyle } from '../../utils/seriesStyles'
 import styles from './PrefectureSelector.module.css'
 
 export const PrefectureSelector = () => {
-  const { populations, addPrefecture, removePrefecture } =
-    usePopulationContext()
-  const { prefectures, loading, error } = usePrefectures()
-  const [selectedCodes, setSelectedCodes] = useState<Set<number>>(new Set())
+  const {
+    populations,
+    selectedCodes,
+    loadingCodes,
+    error: populationError,
+    addPrefecture,
+    removePrefecture,
+  } = usePopulationContext()
+  const { prefectures, loading, error: prefecturesError } = usePrefectures()
 
   const styleIndexMap = useMemo(() => {
     const map = new Map<number, number>()
@@ -20,14 +25,8 @@ export const PrefectureSelector = () => {
   const handleChange = useCallback(
     (prefCode: number, prefName: string, checked: boolean) => {
       if (checked) {
-        setSelectedCodes((prev) => new Set(prev).add(prefCode))
         addPrefecture(prefCode, prefName)
       } else {
-        setSelectedCodes((prev) => {
-          const next = new Set(prev)
-          next.delete(prefCode)
-          return next
-        })
         removePrefecture(prefCode)
       }
     },
@@ -37,28 +36,37 @@ export const PrefectureSelector = () => {
   return (
     <div className={styles.container}>
       {loading && <p className={styles.loading}>読み込み中...</p>}
-      {error && <p className={styles.error}>エラー: {error}</p>}
-      {!loading && !error && (
+      {prefecturesError && (
+        <p className={styles.error}>エラー: {prefecturesError}</p>
+      )}
+      {populationError && <p className={styles.error}>{populationError}</p>}
+      {!loading && !prefecturesError && (
         <div className={styles.grid}>
           {prefectures.map((pref) => {
+            const isSelected = selectedCodes.has(pref.prefCode)
+            const isLoading = loadingCodes.has(pref.prefCode)
             const styleIndex = styleIndexMap.get(pref.prefCode)
             const style =
               styleIndex !== undefined ? getSeriesStyle(styleIndex) : undefined
             return (
               <label
                 key={pref.prefCode}
-                className={`${styles.label} ${selectedCodes.has(pref.prefCode) ? styles.selected : ''}`}
+                className={`${styles.label} ${isSelected ? styles.selected : ''}`}
               >
                 <input
                   type="checkbox"
                   className={styles.checkbox}
                   name="prefecture"
-                  checked={selectedCodes.has(pref.prefCode)}
+                  checked={isSelected}
+                  disabled={isLoading}
                   onChange={(e) =>
                     handleChange(pref.prefCode, pref.prefName, e.target.checked)
                   }
                 />
                 {pref.prefName}
+                {isLoading && (
+                  <span className={styles.spinner} aria-label="読み込み中" />
+                )}
                 {style && (
                   <span
                     className={styles.legendIcon}

--- a/hosting/src/context/PopulationContext.tsx
+++ b/hosting/src/context/PopulationContext.tsx
@@ -13,13 +13,23 @@ export const PopulationProvider = ({
   children,
   initialType,
 }: PopulationProviderProps) => {
-  const { populations, addPrefecture, removePrefecture } = usePopulation()
+  const {
+    populations,
+    selectedCodes,
+    loadingCodes,
+    error,
+    addPrefecture,
+    removePrefecture,
+  } = usePopulation()
 
   return (
     <PopulationContext.Provider
       value={{
         populations,
         populationType: initialType,
+        selectedCodes,
+        loadingCodes,
+        error,
         addPrefecture,
         removePrefecture,
       }}

--- a/hosting/src/context/populationContextValue.ts
+++ b/hosting/src/context/populationContextValue.ts
@@ -6,6 +6,9 @@ import type { PopulationType } from '../types'
 export interface PopulationContextValue {
   populations: PrefPopulation[]
   populationType: PopulationType
+  selectedCodes: Set<number>
+  loadingCodes: Set<number>
+  error: string | null
   addPrefecture: (prefCode: number, prefName: string) => Promise<void>
   removePrefecture: (prefCode: number) => void
 }

--- a/hosting/src/hooks/usePopulation.ts
+++ b/hosting/src/hooks/usePopulation.ts
@@ -10,34 +10,86 @@ export interface PrefPopulation {
   data: PopulationComposition[]
 }
 
+const LOADING_DELAY_MS = 300
+
 export const usePopulation = () => {
   const [populations, setPopulations] = useState<PrefPopulation[]>([])
+  const [selectedCodes, setSelectedCodes] = useState<Set<number>>(new Set())
+  const [loadingCodes, setLoadingCodes] = useState<Set<number>>(new Set())
+  const [error, setError] = useState<string | null>(null)
   const cache = useRef<Map<number, PopulationComposition[]>>(new Map())
   const styleCounter = useRef(0)
-  const selectedRef = useRef<Set<number>>(new Set())
+  const fetchingRef = useRef<Set<number>>(new Set())
 
   const addPrefecture = useCallback(
     async (prefCode: number, prefName: string) => {
-      selectedRef.current.add(prefCode)
-      let data = cache.current.get(prefCode)
-      if (!data) {
-        data = await fetchPopulation(prefCode)
-        cache.current.set(prefCode, data)
+      if (fetchingRef.current.has(prefCode)) return
+      setError(null)
+      setSelectedCodes((prev) => new Set(prev).add(prefCode))
+
+      const cached = cache.current.get(prefCode)
+      if (cached) {
+        const styleIndex = styleCounter.current++
+        setPopulations((prev) => {
+          if (prev.some((p) => p.prefCode === prefCode)) return prev
+          return [...prev, { prefCode, prefName, styleIndex, data: cached }]
+        })
+        return
       }
-      if (!selectedRef.current.has(prefCode)) return
-      const styleIndex = styleCounter.current++
-      setPopulations((prev) => {
-        if (prev.some((p) => p.prefCode === prefCode)) return prev
-        return [...prev, { prefCode, prefName, styleIndex, data }]
-      })
+
+      fetchingRef.current.add(prefCode)
+      const timer = setTimeout(() => {
+        if (fetchingRef.current.has(prefCode)) {
+          setLoadingCodes((prev) => new Set(prev).add(prefCode))
+        }
+      }, LOADING_DELAY_MS)
+
+      try {
+        const fetched = await fetchPopulation(prefCode)
+        cache.current.set(prefCode, fetched)
+
+        if (!fetchingRef.current.has(prefCode)) return
+        const styleIndex = styleCounter.current++
+        setPopulations((prev) => {
+          if (prev.some((p) => p.prefCode === prefCode)) return prev
+          return [...prev, { prefCode, prefName, styleIndex, data: fetched }]
+        })
+      } catch {
+        setSelectedCodes((prev) => {
+          const next = new Set(prev)
+          next.delete(prefCode)
+          return next
+        })
+        setError('グラフデータの読み込みに失敗しました')
+      } finally {
+        clearTimeout(timer)
+        fetchingRef.current.delete(prefCode)
+        setLoadingCodes((prev) => {
+          const next = new Set(prev)
+          next.delete(prefCode)
+          return next
+        })
+      }
     },
     []
   )
 
   const removePrefecture = useCallback((prefCode: number) => {
-    selectedRef.current.delete(prefCode)
+    fetchingRef.current.delete(prefCode)
+    setSelectedCodes((prev) => {
+      const next = new Set(prev)
+      next.delete(prefCode)
+      return next
+    })
     setPopulations((prev) => prev.filter((p) => p.prefCode !== prefCode))
   }, [])
 
-  return { populations, addPrefecture, removePrefecture }
+  return {
+    populations,
+    selectedCodes,
+    loadingCodes,
+    error,
+    addPrefecture,
+    removePrefecture,
+  }
 }


### PR DESCRIPTION
## Issues

https://github.com/marucc/frontend-engineer-codecheck/issues/31
https://github.com/marucc/frontend-engineer-codecheck/issues/30

## なに

- 都道府県チェック状態管理を一元化
- チェック時にdisabledにし、300msAPI応答が遅延した場合はローディング表示
