### PR TITLE
fix: pnpm deployをviteプラグインに統合し、CI時のみクリーンlockfile生成

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fec/functions",
   "scripts": {
-    "build": "rm -rf dist && pnpm --filter @fec/functions --prod deploy dist && vite build",
+    "build": "vite build",
     "build:watch": "vite build --watch",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/functions/vite.config.ts
+++ b/functions/vite.config.ts
@@ -1,18 +1,57 @@
-import { copyFileSync, existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { execSync } from 'node:child_process'
+import {
+  copyFileSync,
+  existsSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
 import { join } from 'node:path'
 
 import { defineConfig } from 'vite'
 import type { Plugin } from 'vite'
 
 function deployPackagePlugin(): Plugin {
+  const pkgPath = join(__dirname, 'package.json')
+  const distDir = join(__dirname, 'dist')
+  const rootDir = join(__dirname, '..')
+  const isCI = !!process.env.CI
+
   return {
     name: 'deploy-package',
-    closeBundle() {
-      const distDir = join(__dirname, 'dist')
 
+    buildStart() {
+      const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'))
+
+      if (isCI) {
+        // CI: Remove devDependencies before deploy for clean lockfile
+        const original = readFileSync(pkgPath, 'utf-8')
+        delete pkg.devDependencies
+        writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n')
+
+        rmSync(distDir, { recursive: true, force: true })
+        try {
+          execSync(`pnpm --filter ${pkg.name} --prod deploy ${distDir}`, {
+            cwd: rootDir,
+            stdio: 'inherit',
+          })
+        } finally {
+          writeFileSync(pkgPath, original)
+        }
+      } else {
+        // Local/Docker: deploy as-is (lockfile doesn't need to be clean)
+        rmSync(distDir, { recursive: true, force: true })
+        execSync(`pnpm --filter ${pkg.name} --prod deploy ${distDir}`, {
+          cwd: rootDir,
+          stdio: 'inherit',
+        })
+      }
+    },
+
+    closeBundle() {
       // Build deploy package.json with only required fields
-      const pkgPath = join(distDir, 'package.json')
-      const src = JSON.parse(readFileSync(pkgPath, 'utf-8'))
+      const deployPkgPath = join(distDir, 'package.json')
+      const src = JSON.parse(readFileSync(deployPkgPath, 'utf-8'))
       const deps: Record<string, string> = {}
       for (const [key, value] of Object.entries(
         src.dependencies as Record<string, string>
@@ -26,7 +65,7 @@ function deployPackagePlugin(): Plugin {
         dependencies: deps,
         private: true,
       }
-      writeFileSync(pkgPath, JSON.stringify(deployPkg, null, 2) + '\n')
+      writeFileSync(deployPkgPath, JSON.stringify(deployPkg, null, 2) + '\n')
 
       // Copy .secret.local for emulator
       const secretSrc = join(__dirname, '.secret.local')


### PR DESCRIPTION
## Issues

https://github.com/marucc/frontend-engineer-codecheck/issues/41

## なに

- buildStart でpnpm deployを実行。CI環境ではdevDependenciesを一時的に 除去してからdeployすることで、Cloud Buildの--frozen-lockfileと互換性のある クリーンなpnpm-lock.yamlを生成する。
- ローカル/Dockerではそのままdeploy。
