### PR TITLE
fix: viteプラグインのdeploy処理を整理

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -21,8 +21,8 @@
     "firebase-functions": "^7.1.0"
   },
   "devDependencies": {
-    "@fec/shared": "workspace:*",
     "@eslint/js": "^9.39.4",
+    "@fec/shared": "workspace:*",
     "@types/express": "^5.0.6",
     "@types/node": "^22.19.15",
     "eslint": "^9.39.4",
@@ -32,6 +32,7 @@
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.56.1",
     "vite": "^7.3.1",
+    "vite-plugin-static-copy": "^4.0.0",
     "vitest": "^4.0.18"
   },
   "private": true

--- a/functions/vite.config.ts
+++ b/functions/vite.config.ts
@@ -1,55 +1,53 @@
 import { execSync } from 'node:child_process'
-import {
-  copyFileSync,
-  existsSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from 'node:fs'
+import { createHash } from 'node:crypto'
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import { defineConfig } from 'vite'
 import type { Plugin } from 'vite'
+import { viteStaticCopy } from 'vite-plugin-static-copy'
+
+function computeDeployHash(pkgPath: string, rootDir: string): string {
+  const pkgContent = readFileSync(pkgPath, 'utf-8')
+  const lockContent = readFileSync(join(rootDir, 'pnpm-lock.yaml'), 'utf-8')
+  return createHash('sha256')
+    .update(pkgContent)
+    .update(lockContent)
+    .digest('hex')
+    .slice(0, 16)
+}
+
+function needsDeploy(distDir: string, currentHash: string): boolean {
+  if (!existsSync(join(distDir, 'node_modules'))) return true
+  const distPkgPath = join(distDir, 'package.json')
+  if (!existsSync(distPkgPath)) return true
+  const distPkg = JSON.parse(readFileSync(distPkgPath, 'utf-8'))
+  return distPkg._deployHash !== currentHash
+}
 
 function deployPackagePlugin(): Plugin {
   const pkgPath = join(__dirname, 'package.json')
   const distDir = join(__dirname, 'dist')
   const rootDir = join(__dirname, '..')
-  const isCI = !!process.env.CI
 
   return {
     name: 'deploy-package',
 
     buildStart() {
       const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'))
+      const hash = computeDeployHash(pkgPath, rootDir)
 
-      if (isCI) {
-        // CI: Remove devDependencies before deploy for clean lockfile
-        const original = readFileSync(pkgPath, 'utf-8')
-        delete pkg.devDependencies
-        writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n')
+      // Watch: skip if dist is up to date
+      if (this.meta.watchMode && !needsDeploy(distDir, hash)) return
 
-        rmSync(distDir, { recursive: true, force: true })
-        try {
-          execSync(`pnpm --filter ${pkg.name} --prod deploy ${distDir}`, {
-            cwd: rootDir,
-            stdio: 'inherit',
-          })
-        } finally {
-          writeFileSync(pkgPath, original)
-        }
-      } else {
-        // Local/Docker: deploy as-is (lockfile doesn't need to be clean)
-        rmSync(distDir, { recursive: true, force: true })
-        execSync(`pnpm --filter ${pkg.name} --prod deploy ${distDir}`, {
-          cwd: rootDir,
-          stdio: 'inherit',
-        })
-      }
-    },
+      // Deploy production dependencies from lockfile
+      rmSync(distDir, { recursive: true, force: true })
+      execSync(`pnpm --filter ${pkg.name} --prod deploy ${distDir}`, {
+        cwd: rootDir,
+        stdio: 'inherit',
+      })
 
-    closeBundle() {
-      // Build deploy package.json with only required fields
+      // Clean dist/package.json for Firebase Cloud Build
       const deployPkgPath = join(distDir, 'package.json')
       const src = JSON.parse(readFileSync(deployPkgPath, 'utf-8'))
       const deps: Record<string, string> = {}
@@ -58,29 +56,41 @@ function deployPackagePlugin(): Plugin {
       )) {
         deps[key] = value.replace(/\(.+\)$/, '')
       }
-      const deployPkg = {
-        name: src.name,
-        engines: src.engines,
-        main: 'index.js',
-        dependencies: deps,
-        private: true,
-      }
-      writeFileSync(deployPkgPath, JSON.stringify(deployPkg, null, 2) + '\n')
+      writeFileSync(
+        deployPkgPath,
+        JSON.stringify(
+          {
+            name: src.name,
+            engines: src.engines,
+            main: 'index.js',
+            dependencies: deps,
+            private: true,
+            _deployHash: hash,
+          },
+          null,
+          2
+        ) + '\n'
+      )
 
-      // Copy .secret.local for emulator
-      const secretSrc = join(__dirname, '.secret.local')
-      if (existsSync(secretSrc)) {
-        copyFileSync(secretSrc, join(distDir, '.secret.local'))
-      }
-
-      console.log('Deploy artifacts generated in dist/')
+      // Regenerate lockfile to match cleaned package.json
+      execSync(
+        'pnpm install --lockfile-only --no-frozen-lockfile --ignore-workspace',
+        { cwd: distDir, stdio: 'inherit' }
+      )
     },
   }
 }
 
 export default defineConfig({
   envPrefix: 'ENV_',
-  plugins: [deployPackagePlugin()],
+  plugins: [
+    deployPackagePlugin(),
+    viteStaticCopy({
+      targets: [{ src: '.secret.local', dest: '.' }],
+      silent: true,
+      environment: 'ssr',
+    }),
+  ],
   build: {
     ssr: 'src/index.ts',
     outDir: 'dist',

--- a/hosting/package.json
+++ b/hosting/package.json
@@ -20,8 +20,8 @@
     "react-router-dom": "^7.13.1"
   },
   "devDependencies": {
-    "@fec/shared": "workspace:*",
     "@eslint/js": "^9.39.4",
+    "@fec/shared": "workspace:*",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,6 +70,9 @@ importers:
       vite:
         specifier: ^7.3.1
         version: 7.3.1(@types/node@22.19.15)(jiti@2.6.1)(yaml@2.8.2)
+      vite-plugin-static-copy:
+        specifier: ^4.0.0
+        version: 4.0.0(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(yaml@2.8.2))
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(jiti@2.6.1)(jsdom@28.1.0)(yaml@2.8.2)
@@ -5081,6 +5084,12 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
+  vite-plugin-static-copy@4.0.0:
+    resolution: {integrity: sha512-TTf6cVTV4M2pH2Wfr3zhevdRsIQezfm2ltDkSfkjqvvdryJHYQyNoPISvuytX3r9jFZV0yVeMYyGTsAvAH2XLw==}
+    engines: {node: ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+
   vite@7.3.1:
     resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -9832,8 +9841,7 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
-  p-map@7.0.4:
-    optional: true
+  p-map@7.0.4: {}
 
   p-throttle@7.0.0: {}
 
@@ -10985,6 +10993,14 @@ snapshots:
   validate-npm-package-name@5.0.1: {}
 
   vary@1.1.2: {}
+
+  vite-plugin-static-copy@4.0.0(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(yaml@2.8.2)):
+    dependencies:
+      chokidar: 3.6.0
+      p-map: 7.0.4
+      picocolors: 1.1.1
+      tinyglobby: 0.2.15
+      vite: 7.3.1(@types/node@22.19.15)(jiti@2.6.1)(yaml@2.8.2)
 
   vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(yaml@2.8.2):
     dependencies:


### PR DESCRIPTION
## Issues

https://github.com/marucc/frontend-engineer-codecheck/issues/41

## なに

- buildStart でpnpm deploy + package.jsonクリーンアップ + lockfile再生成を一括実行
- watch時はdeployHashで変更検知し、不要ならスキップ
- vite-plugin-static-copyで.secret.localをSSRビルド時にコピー
- functions/package.jsonの書き換え不要に
- docker-compose: pnpm build後にbuild:watchで差分監視


