### PR TITLE
fix: API呼び出し時の排他制御修正、disabledにはせずに呼び出しのみ1回にする

### DIFF
--- a/hosting/src/components/chart/Chart.test.tsx
+++ b/hosting/src/components/chart/Chart.test.tsx
@@ -30,8 +30,7 @@ describe('Chart', () => {
       selectedCodes: new Set<number>(),
       loadingCodes: new Set<number>(),
       error: null,
-      addPrefecture: vi.fn(),
-      removePrefecture: vi.fn(),
+      togglePrefecture: vi.fn(),
     })
 
     render(<Chart />)
@@ -60,8 +59,7 @@ describe('Chart', () => {
       selectedCodes: new Set<number>(),
       loadingCodes: new Set<number>(),
       error: null,
-      addPrefecture: vi.fn(),
-      removePrefecture: vi.fn(),
+      togglePrefecture: vi.fn(),
     })
 
     render(<Chart />)

--- a/hosting/src/components/controls/PrefectureSelector.test.tsx
+++ b/hosting/src/components/controls/PrefectureSelector.test.tsx
@@ -3,8 +3,7 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import { usePrefectures } from '../../hooks/usePrefectures'
 import { PrefectureSelector } from './PrefectureSelector'
 
-const mockAddPrefecture = vi.fn()
-const mockRemovePrefecture = vi.fn()
+const mockTogglePrefecture = vi.fn()
 let mockSelectedCodes = new Set<number>()
 
 vi.mock('../../hooks/usePrefectures', () => ({
@@ -19,8 +18,7 @@ vi.mock('../../hooks/usePopulationContext', () => ({
     },
     loadingCodes: new Set<number>(),
     error: null,
-    addPrefecture: mockAddPrefecture,
-    removePrefecture: mockRemovePrefecture,
+    togglePrefecture: mockTogglePrefecture,
   }),
 }))
 
@@ -49,7 +47,7 @@ describe('PrefectureSelector', () => {
     expect(screen.getByLabelText('大阪府')).toBeInTheDocument()
   })
 
-  it('チェックボックスをクリックすると addPrefecture が呼ばれる', () => {
+  it('チェックボックスをクリックすると togglePrefecture が呼ばれる', () => {
     vi.mocked(usePrefectures).mockReturnValue({
       prefectures: mockPrefectures,
       loading: false,
@@ -58,10 +56,10 @@ describe('PrefectureSelector', () => {
 
     render(<PrefectureSelector />)
     fireEvent.click(screen.getByLabelText('東京都'))
-    expect(mockAddPrefecture).toHaveBeenCalledWith(13, '東京都')
+    expect(mockTogglePrefecture).toHaveBeenCalledWith(13, '東京都')
   })
 
-  it('チェック済みを外すと removePrefecture が呼ばれる', () => {
+  it('チェック済みを外すと togglePrefecture が呼ばれる', () => {
     mockSelectedCodes = new Set([13])
 
     vi.mocked(usePrefectures).mockReturnValue({
@@ -72,7 +70,7 @@ describe('PrefectureSelector', () => {
 
     render(<PrefectureSelector />)
     fireEvent.click(screen.getByLabelText('東京都'))
-    expect(mockRemovePrefecture).toHaveBeenCalledWith(13)
+    expect(mockTogglePrefecture).toHaveBeenCalledWith(13, '東京都')
   })
 
   it('loading 中は読み込み中と表示される', () => {

--- a/hosting/src/components/controls/PrefectureSelector.tsx
+++ b/hosting/src/components/controls/PrefectureSelector.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react'
+import { useMemo } from 'react'
 
 import { usePopulationContext } from '../../hooks/usePopulationContext'
 import { usePrefectures } from '../../hooks/usePrefectures'
@@ -11,8 +11,7 @@ export const PrefectureSelector = () => {
     selectedCodes,
     loadingCodes,
     error: populationError,
-    addPrefecture,
-    removePrefecture,
+    togglePrefecture,
   } = usePopulationContext()
   const { prefectures, loading, error: prefecturesError } = usePrefectures()
 
@@ -21,17 +20,6 @@ export const PrefectureSelector = () => {
     populations.forEach((p) => map.set(p.prefCode, p.styleIndex))
     return map
   }, [populations])
-
-  const handleChange = useCallback(
-    (prefCode: number, prefName: string, checked: boolean) => {
-      if (checked) {
-        addPrefecture(prefCode, prefName)
-      } else {
-        removePrefecture(prefCode)
-      }
-    },
-    [addPrefecture, removePrefecture]
-  )
 
   return (
     <div className={styles.container}>
@@ -58,13 +46,12 @@ export const PrefectureSelector = () => {
                   className={styles.checkbox}
                   name="prefecture"
                   checked={isSelected}
-                  disabled={isLoading}
-                  onChange={(e) =>
-                    handleChange(pref.prefCode, pref.prefName, e.target.checked)
+                  onChange={() =>
+                    togglePrefecture(pref.prefCode, pref.prefName)
                   }
                 />
                 {pref.prefName}
-                {isLoading && (
+                {isLoading && isSelected && (
                   <span className={styles.spinner} aria-label="読み込み中" />
                 )}
                 {style && (

--- a/hosting/src/context/PopulationContext.test.tsx
+++ b/hosting/src/context/PopulationContext.test.tsx
@@ -50,14 +50,14 @@ describe('PopulationContext', () => {
     const { result } = renderHook(() => usePopulationContext(), { wrapper })
 
     await act(async () => {
-      await result.current.addPrefecture(1, '北海道')
+      await result.current.togglePrefecture(1, '北海道')
     })
 
     expect(result.current.populations).toHaveLength(1)
     expect(result.current.populations[0].prefName).toBe('北海道')
 
     act(() => {
-      result.current.removePrefecture(1)
+      result.current.togglePrefecture(1, '北海道')
     })
 
     expect(result.current.populations).toHaveLength(0)

--- a/hosting/src/context/PopulationContext.tsx
+++ b/hosting/src/context/PopulationContext.tsx
@@ -13,14 +13,8 @@ export const PopulationProvider = ({
   children,
   initialType,
 }: PopulationProviderProps) => {
-  const {
-    populations,
-    selectedCodes,
-    loadingCodes,
-    error,
-    addPrefecture,
-    removePrefecture,
-  } = usePopulation()
+  const { populations, selectedCodes, loadingCodes, error, togglePrefecture } =
+    usePopulation()
 
   return (
     <PopulationContext.Provider
@@ -30,8 +24,7 @@ export const PopulationProvider = ({
         selectedCodes,
         loadingCodes,
         error,
-        addPrefecture,
-        removePrefecture,
+        togglePrefecture,
       }}
     >
       {children}

--- a/hosting/src/context/populationContextValue.ts
+++ b/hosting/src/context/populationContextValue.ts
@@ -9,8 +9,7 @@ export interface PopulationContextValue {
   selectedCodes: Set<number>
   loadingCodes: Set<number>
   error: string | null
-  addPrefecture: (prefCode: number, prefName: string) => Promise<void>
-  removePrefecture: (prefCode: number) => void
+  togglePrefecture: (prefCode: number, prefName: string) => Promise<void>
 }
 
 export const PopulationContext = createContext<PopulationContextValue | null>(

--- a/hosting/src/hooks/usePopulation.test.ts
+++ b/hosting/src/hooks/usePopulation.test.ts
@@ -26,14 +26,14 @@ describe('usePopulation', () => {
     const { result } = renderHook(() => usePopulation())
 
     await act(async () => {
-      await result.current.addPrefecture(1, '北海道')
+      await result.current.togglePrefecture(1, '北海道')
     })
 
     expect(result.current.populations).toHaveLength(1)
     expect(result.current.populations[0].prefName).toBe('北海道')
 
     act(() => {
-      result.current.removePrefecture(1)
+      result.current.togglePrefecture(1, '北海道')
     })
 
     expect(result.current.populations).toHaveLength(0)
@@ -48,7 +48,7 @@ describe('usePopulation', () => {
     const { result } = renderHook(() => usePopulation())
 
     await act(async () => {
-      await result.current.addPrefecture(1, '北海道')
+      await result.current.togglePrefecture(1, '北海道')
     })
 
     expect(result.current.populations[0].styleIndex).toBeDefined()
@@ -64,13 +64,13 @@ describe('usePopulation', () => {
     const { result } = renderHook(() => usePopulation())
 
     await act(async () => {
-      await result.current.addPrefecture(1, '北海道')
+      await result.current.togglePrefecture(1, '北海道')
     })
     await act(async () => {
-      await result.current.addPrefecture(13, '東京都')
+      await result.current.togglePrefecture(13, '東京都')
     })
     await act(async () => {
-      await result.current.addPrefecture(27, '大阪府')
+      await result.current.togglePrefecture(27, '大阪府')
     })
 
     const indices = result.current.populations.map((p) => p.styleIndex)
@@ -87,15 +87,15 @@ describe('usePopulation', () => {
     const { result } = renderHook(() => usePopulation())
 
     await act(async () => {
-      await result.current.addPrefecture(1, '北海道')
+      await result.current.togglePrefecture(1, '北海道')
     })
 
     act(() => {
-      result.current.removePrefecture(1)
+      result.current.togglePrefecture(1, '北海道') // OFF
     })
 
     await act(async () => {
-      await result.current.addPrefecture(1, '北海道')
+      await result.current.togglePrefecture(1, '北海道') // ON again
     })
 
     expect(fetchSpy).toHaveBeenCalledTimes(1)

--- a/hosting/src/hooks/usePopulation.ts
+++ b/hosting/src/hooks/usePopulation.ts
@@ -20,10 +20,35 @@ export const usePopulation = () => {
   const cache = useRef<Map<number, PopulationComposition[]>>(new Map())
   const styleCounter = useRef(0)
   const fetchingRef = useRef<Set<number>>(new Set())
+  const cancelledRef = useRef<Set<number>>(new Set())
+  const selectedRef = useRef<Set<number>>(new Set())
 
-  const addPrefecture = useCallback(
+  const togglePrefecture = useCallback(
     async (prefCode: number, prefName: string) => {
-      if (fetchingRef.current.has(prefCode)) return
+      if (selectedRef.current.has(prefCode)) {
+        // OFF
+        selectedRef.current.delete(prefCode)
+        cancelledRef.current.add(prefCode)
+        setSelectedCodes((prev) => {
+          const next = new Set(prev)
+          next.delete(prefCode)
+          return next
+        })
+        setPopulations((prev) => prev.filter((p) => p.prefCode !== prefCode))
+        return
+      }
+
+      // ON
+      if (fetchingRef.current.has(prefCode)) {
+        // Re-check during fetch: cancel the cancellation
+        selectedRef.current.add(prefCode)
+        cancelledRef.current.delete(prefCode)
+        setSelectedCodes((prev) => new Set(prev).add(prefCode))
+        return
+      }
+
+      selectedRef.current.add(prefCode)
+      fetchingRef.current.add(prefCode)
       setError(null)
       setSelectedCodes((prev) => new Set(prev).add(prefCode))
 
@@ -34,10 +59,10 @@ export const usePopulation = () => {
           if (prev.some((p) => p.prefCode === prefCode)) return prev
           return [...prev, { prefCode, prefName, styleIndex, data: cached }]
         })
+        fetchingRef.current.delete(prefCode)
         return
       }
 
-      fetchingRef.current.add(prefCode)
       const timer = setTimeout(() => {
         if (fetchingRef.current.has(prefCode)) {
           setLoadingCodes((prev) => new Set(prev).add(prefCode))
@@ -48,13 +73,14 @@ export const usePopulation = () => {
         const fetched = await fetchPopulation(prefCode)
         cache.current.set(prefCode, fetched)
 
-        if (!fetchingRef.current.has(prefCode)) return
+        if (cancelledRef.current.has(prefCode)) return
         const styleIndex = styleCounter.current++
         setPopulations((prev) => {
           if (prev.some((p) => p.prefCode === prefCode)) return prev
           return [...prev, { prefCode, prefName, styleIndex, data: fetched }]
         })
       } catch {
+        selectedRef.current.delete(prefCode)
         setSelectedCodes((prev) => {
           const next = new Set(prev)
           next.delete(prefCode)
@@ -64,6 +90,7 @@ export const usePopulation = () => {
       } finally {
         clearTimeout(timer)
         fetchingRef.current.delete(prefCode)
+        cancelledRef.current.delete(prefCode)
         setLoadingCodes((prev) => {
           const next = new Set(prev)
           next.delete(prefCode)
@@ -74,22 +101,11 @@ export const usePopulation = () => {
     []
   )
 
-  const removePrefecture = useCallback((prefCode: number) => {
-    fetchingRef.current.delete(prefCode)
-    setSelectedCodes((prev) => {
-      const next = new Set(prev)
-      next.delete(prefCode)
-      return next
-    })
-    setPopulations((prev) => prev.filter((p) => p.prefCode !== prefCode))
-  }, [])
-
   return {
     populations,
     selectedCodes,
     loadingCodes,
     error,
-    addPrefecture,
-    removePrefecture,
+    togglePrefecture,
   }
 }


### PR DESCRIPTION
## Issues

https://github.com/marucc/frontend-engineer-codecheck/issues/30

## なに

- チェック時のdisabledは廃止
- ユーザはfetch中でもチェックon/offできる
- onの間に読み込み中だったらローディングが表示される
